### PR TITLE
Adjust to new ose piping workbench

### DIFF
--- a/D3D_AddPvcFrame.py
+++ b/D3D_AddPvcFrame.py
@@ -10,7 +10,7 @@
 #*  modify it under the terms of the GNU Lesser General Public             *
 #*  License as published by the Free Software Foundation; either           *
 #*  version 2 of the License, or (at your option) any later version.       *
-#*                                                                         *            
+#*                                                                         *
 #*  This library is distributed in the hope that it will be useful,        *
 #*  but WITHOUT ANY WARRANTY; without even the implied warranty of         *
 #*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU      *
@@ -28,7 +28,8 @@ import FreeCAD as App
 import FreeCADGui as Gui
 import D3DInit
 from PySide import QtGui#, QtCore # https://www.freecadweb.org/wiki/PySide
-import pipeGui, cornerGui
+import OsePiping.PipeGui as PipeGui
+import OsePiping.CornerGui as CornerGui
 import PvcFrameGui
 
 class D3D_AddPvcFrameClass():
@@ -46,8 +47,8 @@ class D3D_AddPvcFrameClass():
             App.newDocument()
 
         doc = App.activeDocument()
-	pipeTable = pipeGui.GuiCheckTable() # Open a CSV file, check its content, and return it as a CsvTable object.
-	cornerTable = cornerGui.GuiCheckTable() # Open a CSV file, check its content, and return it as a CsvTable object.
+	pipeTable = PipeGui.GuiCheckTable() # Open a CSV file, check its content, and return it as a CsvTable object.
+	cornerTable = CornerGui.GuiCheckTable() # Open a CSV file, check its content, and return it as a CsvTable object.
 	form = PvcFrameGui.MainDialog(doc, pipeTable, cornerTable)
 	form.exec_()
         Gui.ActiveDocument.ActiveView.fitAll()
@@ -59,4 +60,4 @@ class D3D_AddPvcFrameClass():
         are met or not. This function is optional."""
         return True
 
-Gui.addCommand('D3D_AddPvcFrame', D3D_AddPvcFrameClass()) 
+Gui.addCommand('D3D_AddPvcFrame', D3D_AddPvcFrameClass())

--- a/PvcFrame.py
+++ b/PvcFrame.py
@@ -37,7 +37,7 @@ import Draft
 
 import OSEBase
 from piping import *
-import outerCorner
+import corner as cornermod
 import pipe as pipemod
 
 parseQuantity = FreeCAD.Units.parseQuantity
@@ -75,7 +75,7 @@ class Box:
 		self.LZ = parseQuantity("25 in")
 		self.POD = parseQuantity("3 cm")
 		self.Thk = parseQuantity("0.5 cm")
-		self.corner = outerCorner.OuterCorner(document)
+		self.corner = cornermod.Corner(document)
 		
 	def checkDimensions(self):
 		if not ( self.POD > parseQuantity("0 mm") and self.Thk > parseQuantity("0 mm") ):
@@ -193,7 +193,7 @@ class BoxFromTable:
 		self.LZ = parseQuantity("8 in")
 
 	def getCorner(self, partName):
-		corner = outerCorner.OuterCorner(self.document)
+		corner = cornermod.Corner(self.document)
 		row = self.corner_table.findPart(partName)
 		if row is None:
 			print('Corner part "%s" not found'%partName)
@@ -235,7 +235,7 @@ def TestTable():
 	pipe_table = CsvTable(PIPE_DIMENSIONS_USED)
 	corner_table = CsvTable(CORNER_DIMENSIONS_USED)
 	pipe_table.load(pipemod.CSV_TABLE_PATH)
-	corner_table.load(outerCorner.CSV_TABLE_PATH)
+	corner_table.load(outer.CSV_TABLE_PATH)
 	box = BoxFromTable(document, pipe_table, corner_table)
 	pipeName = pipe_table.getPartName(0)
 	cornerName = corner_table.getPartName(0)

--- a/PvcFrame.py
+++ b/PvcFrame.py
@@ -169,11 +169,11 @@ class BoxFromTable:
 		if row is None:
 			print('Corner part "%s" not found'%partName)
 			return
-		corner.G = parseQuantity(row["G"])
-		corner.H = parseQuantity(row["H"])
-		corner.M = parseQuantity(row["M"])
-		corner.POD = parseQuantity(row["POD"])
-		corner.PThk = parseQuantity(row["PThk"])
+		corner.dims.G = parseQuantity(row["G"])
+		corner.dims.H = parseQuantity(row["H"])
+		corner.dims.M = parseQuantity(row["M"])
+		corner.dims.POD = parseQuantity(row["POD"])
+		corner.dims.PThk = parseQuantity(row["PThk"])
 		return corner
 
 	def create(self, pipeName, cornerName, convertToSolid = True):
@@ -183,14 +183,15 @@ class BoxFromTable:
 		frame_box.LZ = self.LZ
 		# Init corner datata
 		frame_box.corner = self.getCorner(cornerName)
-		frame_box.G = frame_box.corner.G
+		frame_box.G = frame_box.corner.dims.G
 
 		"setup pipe dimensions"
 		row = self.pipe_table.findPart(pipeName)
 		if row is None:
 			print('Pipe part "%s" not found'%pipeName)
 			return
-		frame_box.PID = parseQuantity(row["ID"])
+
+		frame_box.POD = parseQuantity(row["OD"])
 		frame_box.PThk = parseQuantity(row["Thk"])
 		return frame_box.create(convertToSolid)
 
@@ -208,7 +209,8 @@ def TestTable():
 	pipe_table.load(PipeMod.CSV_TABLE_PATH)
 	corner_table.load(CornerMod.CSV_TABLE_PATH)
 	box = BoxFromTable(document, pipe_table, corner_table)
-	pipeName = pipe_table.getPartKey(0)
+	#pipeName = pipe_table.getPartKey(0)
+	pipeName = "NPS 2\" PVC SCH 40"
 	cornerName = corner_table.getPartKey(0)
 
 	print("Using pipe %s"%pipeName)

--- a/PvcFrameGui.py
+++ b/PvcFrameGui.py
@@ -36,7 +36,7 @@ import FreeCAD
 import D3DBase
 from PvcFrame import *
 import pipeGui
-import outerCornerGui
+import cornerGui
 
 class MainDialog(QtGui.QDialog):
 	QSETTINGS_APPLICATION = "OSE D3D-Printer-Workbench"
@@ -262,7 +262,7 @@ class MainDialog(QtGui.QDialog):
 			self.lineEditPipeName.setText(partName)
 			
 	def selectCornerClicked(self):
-		dlg = outerCornerGui.MainDialog(self.document, self.cornerTable)
+		dlg = cornerGui.MainDialog(self.document, self.cornerTable)
 		partName = dlg.showForSelection(self.lineEditCornerName.text())
 		if partName is not None:
 			self.lineEditCornerName.setText(partName)

--- a/PvcFrameGui.py
+++ b/PvcFrameGui.py
@@ -11,7 +11,7 @@
 #*  modify it under the terms of the GNU Lesser General Public             *
 #*  License as published by the Free Software Foundation; either           *
 #*  version 2 of the License, or (at your option) any later version.       *
-#*                                                                         *            
+#*                                                                         *
 #*  This library is distributed in the hope that it will be useful,        *
 #*  but WITHOUT ANY WARRANTY; without even the implied warranty of         *
 #*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU      *
@@ -34,9 +34,12 @@ from PySide import QtCore, QtGui
 import FreeCAD
 
 import D3DBase
-from PvcFrame import *
-import pipeGui
-import cornerGui
+import PvcFrame
+import OsePiping.PipeGui as PipeGui
+import OsePiping.CornerGui as CornerGui
+
+parseQuantity = FreeCAD.Units.parseQuantity
+
 
 class MainDialog(QtGui.QDialog):
 	QSETTINGS_APPLICATION = "OSE D3D-Printer-Workbench"
@@ -48,9 +51,9 @@ class MainDialog(QtGui.QDialog):
 		self.cornerTable = cornerTable
 		self.initUi()
 
-	def initUi(self): 
-		Dialog = self # Added 
-		self.result = -1 
+	def initUi(self):
+		Dialog = self # Added
+		self.result = -1
 		self.setupUi(self)
 		# Restore previous user input. Ignore exceptions to prevent this part
 		# part of the code to prevent GUI from starting, once settings are broken.
@@ -182,7 +185,7 @@ class MainDialog(QtGui.QDialog):
 
 		# Update active document.  If there is none, show a warning message and do nothing.
 		# Get dimensions from the table
-		box = BoxFromTable(self.document, self.pipeTable, self.cornerTable)
+		box = PvcFrame.BoxFromTable(self.document, self.pipeTable, self.cornerTable)
 		box.LX = parseQuantity(self.lineEditLX.text())
 		if box.LX == "":
 			msgBox = QtGui.QMessageBox()
@@ -201,7 +204,7 @@ class MainDialog(QtGui.QDialog):
 			msgBox.setText("Set LZ length.")
 			msgBox.exec_()
 			return
-	
+
 		pipeName = self.lineEditPipeName.text()
 		if pipeName == "":
 			msgBox = QtGui.QMessageBox()
@@ -256,13 +259,13 @@ class MainDialog(QtGui.QDialog):
 			self.lineEditCornerName.setText(text)
 
 	def selectPipeClicked(self):
-		dlg = pipeGui.MainDialog(self.document, self.pipeTable)
+		dlg = PipeGui.MainDialog(self.document, self.pipeTable)
 		partName = dlg.showForSelection(self.lineEditPipeName.text())
 		if partName is not None:
 			self.lineEditPipeName.setText(partName)
-			
+
 	def selectCornerClicked(self):
-		dlg = cornerGui.MainDialog(self.document, self.cornerTable)
+		dlg = CornerGui.MainDialog(self.document, self.cornerTable)
 		partName = dlg.showForSelection(self.lineEditCornerName.text())
 		if partName is not None:
 			self.lineEditCornerName.setText(partName)


### PR DESCRIPTION
I reorganized OSE-piping-workbench: renamed modules and changes some dimensions name.
The old D3D-Printer-Workbench will not more work with the new OSE-piping-workbench.
I updated D3D workbench.